### PR TITLE
Warning nit fix

### DIFF
--- a/SGrottel.SimpleLog.CSharp.nuspec
+++ b/SGrottel.SimpleLog.CSharp.nuspec
@@ -5,7 +5,7 @@
 	<!-- package metadata -->
 	<metadata minClientVersion="3.3">
 		<id>SGrottel.SimpleLog.CSharp</id>
-		<version>3.3.1</version>
+		<version>3.3.2</version>
 		<title>SGrottel.SimpleLog.CSharp</title>
 		<authors>SGrottel</authors>
 		<owners>SGrottel</owners>

--- a/SGrottel.SimpleLog.Cpp.nuspec
+++ b/SGrottel.SimpleLog.Cpp.nuspec
@@ -5,7 +5,7 @@
 	<!-- package metadata -->
 	<metadata>
 		<id>SGrottel.SimpleLog.Cpp</id>
-		<version>3.3.1</version>
+		<version>3.3.2</version>
 		<title>SGrottel SimpleLog Cpp</title>
 		<authors>SGrottel</authors>
 		<owners>SGrottel</owners>

--- a/cpp/SimpleLog/SimpleLog.hpp
+++ b/cpp/SimpleLog/SimpleLog.hpp
@@ -1,5 +1,5 @@
 // SimpleLog.hpp
-// Version: 3.3.1
+// Version: 3.3.2
 //
 // Copyright 2022-2026 SGrottel (www.sgrottel.de)
 //
@@ -19,7 +19,7 @@
 
 #define SIMPLELOG_VER_MAJOR 3
 #define SIMPLELOG_VER_MINOR 3
-#define SIMPLELOG_VER_PATCH 1
+#define SIMPLELOG_VER_PATCH 2
 #define SIMPLELOG_VER_BUILD 0
 
 #if !defined(__cplusplus)
@@ -78,7 +78,7 @@ namespace sgrottel
 		/// <summary>
 		/// Patch version number constant
 		/// </summary>
-		static constexpr int const VERSION_PATCH = 1;
+		static constexpr int const VERSION_PATCH = 2;
 
 		/// <summary>
 		/// Build version number constant

--- a/csharp/SimpleLog/SimpleLog.cs
+++ b/csharp/SimpleLog/SimpleLog.cs
@@ -431,7 +431,7 @@ namespace SGrottel
 			ArgumentNullException.ThrowIfNull(name);
 			ArgumentException.ThrowIfNullOrWhiteSpace(directory);
 			ArgumentException.ThrowIfNullOrWhiteSpace(name);
-			if (retention < 2) throw new ArgumentException(nameof(retention));
+			if (retention < 2) throw new ArgumentException("Retention value must be 2 or larger", paramName: nameof(retention));
 
 			using (Mutex logSetupMutex = new Mutex(false, "SGROTTEL_SIMPLELOG_CREATION"))
 			{

--- a/csharp/SimpleLog/SimpleLog.cs
+++ b/csharp/SimpleLog/SimpleLog.cs
@@ -1,5 +1,5 @@
 // SimpleLog.cs
-// Version: 3.3.1
+// Version: 3.3.2
 //
 // Copyright 2022-2026 SGrottel (www.sgrottel.de)
 //
@@ -50,7 +50,7 @@ namespace SGrottel
 		/// <summary>
 		/// Patch version number constant
 		/// </summary>
-		const int VERSION_PATCH = 1;
+		const int VERSION_PATCH = 2;
 
 		/// <summary>
 		/// Build version number constant


### PR DESCRIPTION
Fixed:
> SimpleLog.cs(434,29): warning CA2208: Method .ctor passes parameter name 'retention' as the message argument to a ArgumentException constructor. Replace this argument with a descriptive message and pass the parameter name in the correct position. (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca2208)